### PR TITLE
작업열 검증 및 종료

### DIFF
--- a/src/main/kotlin/com/flab/inqueue/domain/queue/dto/JobValidationResponse.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/dto/JobValidationResponse.kt
@@ -1,0 +1,5 @@
+package com.flab.inqueue.domain.queue.dto
+
+data class JobValidationResponse(
+    val isJobExisted: Boolean,
+)

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobQueueService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobQueueService.kt
@@ -21,7 +21,7 @@ class JobQueueService(
     }
 
     @Throws(RedisException::class)
-    fun close(job: Job) {
+    fun finish(job: Job) {
         jobQueueRedisRepository.remove(job)
     }
 }

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobQueueService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobQueueService.kt
@@ -1,0 +1,27 @@
+package com.flab.inqueue.domain.queue.service
+
+import com.flab.inqueue.domain.queue.entity.Job
+import com.flab.inqueue.domain.queue.repository.JobQueueRedisRepository
+import io.lettuce.core.RedisException
+import org.springframework.stereotype.Service
+import kotlin.jvm.Throws
+
+@Service
+class JobQueueService(
+    private val jobQueueRedisRepository: JobQueueRedisRepository,
+) {
+
+    fun size(key: String): Long {
+        return jobQueueRedisRepository.size(key)
+    }
+
+    @Throws(RedisException::class)
+    fun isMember(job: Job): Boolean {
+        return jobQueueRedisRepository.isMember(job)
+    }
+
+    @Throws(RedisException::class)
+    fun close(job: Job) {
+        jobQueueRedisRepository.remove(job)
+    }
+}

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
@@ -2,6 +2,7 @@ package com.flab.inqueue.domain.queue.service
 
 import com.flab.inqueue.domain.event.entity.Event
 import com.flab.inqueue.domain.event.repository.EventRepository
+import com.flab.inqueue.domain.queue.dto.JobValidationResponse
 import com.flab.inqueue.domain.queue.dto.QueueResponse
 import com.flab.inqueue.domain.queue.entity.Job
 import com.flab.inqueue.domain.queue.entity.JobStatus
@@ -13,6 +14,11 @@ class JobService(
     private val waitQueueService: WaitQueueService,
     private val jobQueueService: JobQueueService
 ) {
+    fun verify(eventId: String, userId: String) : JobValidationResponse {
+        val job = Job(eventId, userId, JobStatus.ENTER)
+        val result = jobQueueService.isMember(job)
+        return JobValidationResponse(result)
+    }
 
     fun enter(eventId: String, userId: String): QueueResponse {
         val event = findEvent(eventId)

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
@@ -20,6 +20,11 @@ class JobService(
         return JobValidationResponse(result)
     }
 
+    fun finish(eventId: String, userId: String) {
+        val job = Job(eventId, userId, JobStatus.ENTER)
+        jobQueueService.finish(job)
+    }
+
     fun enter(eventId: String, userId: String): QueueResponse {
         val event = findEvent(eventId)
 

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/WaitQueueService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/WaitQueueService.kt
@@ -9,7 +9,7 @@ import com.flab.inqueue.domain.queue.repository.WaitQueueRedisRepository
 import org.springframework.stereotype.Service
 
 @Service
-class QueueService(
+class WaitQueueService(
     private val waitQueueRedisRepository: WaitQueueRedisRepository,
     private val jobQueueRedisRepository: JobQueueRedisRepository,
 ) {
@@ -31,7 +31,7 @@ class QueueService(
     }
 
     fun size(key: String): Long? {
-        return jobQueueRedisRepository.size(key)
+        return waitQueueRedisRepository.size(key)
     }
 
     fun isMember(job: Job): Boolean {

--- a/src/test/kotlin/com/flab/inqueue/domain/queue/service/WaitQueueServiceTest.kt
+++ b/src/test/kotlin/com/flab/inqueue/domain/queue/service/WaitQueueServiceTest.kt
@@ -15,13 +15,13 @@ import org.junit.jupiter.params.provider.EnumSource
 import java.util.*
 
 @UnitTest
-class QueueServiceTest {
+class WaitQueueServiceTest {
 
     @MockK
     lateinit var waitQueueRedisRepository: WaitQueueRedisRepository
 
     @InjectMockKs
-    lateinit var queueService: QueueService
+    lateinit var waitQueueService: WaitQueueService
 
 
     @DisplayName("대기열 및 작업열 진입")
@@ -36,7 +36,7 @@ class QueueServiceTest {
         every { waitQueueRedisRepository.register(any()) } returns Unit
         every { waitQueueRedisRepository.rank(any()) } returns 1
 
-        val queueResponse = queueService.waitQueueRegister(Job(eventId, userId, jobStatus))
+        val queueResponse = waitQueueService.waitQueueRegister(Job(eventId, userId, jobStatus))
 
         //then
         assertThat(queueResponse.status).isEqualTo(jobStatus)
@@ -59,7 +59,7 @@ class QueueServiceTest {
         every { waitQueueRedisRepository.rank(any()) } returns 1
 
         //given
-        val queueResponse = queueService.waitQueueRetrieve(Job(eventId, userId))
+        val queueResponse = waitQueueService.waitQueueRetrieve(Job(eventId, userId))
 
         //then
         assertThat(queueResponse.status).isEqualTo(JobStatus.WAIT)


### PR DESCRIPTION
이슈번호: #28 

- 클래스 이름 변경: QueueService.class -> WaitQueueService.class
- JobQueueService.class 생성: 작업열과 관련된 메소드 추가
- remove, size, isMember 명령어가 null을 반환할 때의 Exception 변경
    - null 을 반환하는 이유가 다른 트랜잭션이 락을 걸 경우, 해당 데이터에 접근 할 수 없어 발생