### PR TITLE
고객사(Member) 회원 가입

### DIFF
--- a/src/main/kotlin/com/flab/inqueue/application/controller/EventController.kt
+++ b/src/main/kotlin/com/flab/inqueue/application/controller/EventController.kt
@@ -3,19 +3,13 @@ package com.flab.inqueue.application.controller
 import com.flab.inqueue.domain.event.dto.EventRequest
 import com.flab.inqueue.domain.event.dto.EventResponse
 import com.flab.inqueue.domain.event.service.EventService
-import com.flab.inqueue.domain.queue.dto.JobResponse
-import com.flab.inqueue.domain.queue.service.JobService
-import com.flab.inqueue.security.common.CommonPrincipal
 import jakarta.validation.Valid
-import org.springframework.http.ResponseEntity
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("client/v1/events")
 class EventController(
     private val eventService: EventService,
-    private val jobService: JobService,
 ) {
     @PostMapping
     fun createEvent(
@@ -23,45 +17,6 @@ class EventController(
         @RequestBody @Valid eventRequest: EventRequest,
     ): EventResponse {
         return eventService.save(eventRequest)
-    }
-
-    @PostMapping("/{eventId}/enter")
-    fun enterWaitQueue(
-        @RequestHeader("Authorization") accessToken: String,
-        @PathVariable("eventId") eventId: String,
-    ): JobResponse {
-        val principal = SecurityContextHolder.getContext().authentication.principal as CommonPrincipal
-        return jobService.enter(eventId,principal.userId )
-    }
-
-
-    @GetMapping("/{eventId}")
-    fun retrieveWaitQueue(
-        @RequestHeader("Authorization") accessToken: String,
-        @PathVariable eventId: String,
-    ): JobResponse {
-        val principal = SecurityContextHolder.getContext().authentication.principal as CommonPrincipal
-        return jobService.retrieve(eventId,principal.userId )
-    }
-
-
-    @PostMapping("/{eventId}/job-queue-check/{userId}")
-    fun validateJobQueue(
-        @RequestHeader("Authorization") accessKey: String,
-        @PathVariable eventId: String,
-        @PathVariable userId: String,
-    ): ResponseEntity<Unit> {
-        return ResponseEntity.ok().build()
-    }
-
-
-    @PostMapping("/{eventId}/job-queue-finish/{userId}")
-    fun closeJopQueue(
-        @RequestHeader("Authorization") accessKey: String,
-        @PathVariable eventId: String,
-        @PathVariable userId: String,
-    ): ResponseEntity<Unit> {
-        return ResponseEntity.ok().build()
     }
 }
 

--- a/src/main/kotlin/com/flab/inqueue/application/controller/MemberController.kt
+++ b/src/main/kotlin/com/flab/inqueue/application/controller/MemberController.kt
@@ -1,0 +1,21 @@
+package com.flab.inqueue.application.controller
+
+import com.flab.inqueue.domain.member.dto.MemberSignUpRequest
+import com.flab.inqueue.domain.member.dto.MemberSignUpResponse
+import com.flab.inqueue.domain.member.service.MemberService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/server/v1/members")
+class MemberController(
+    private val memberService: MemberService
+) {
+
+    @PostMapping
+    fun signUp(@RequestBody request: MemberSignUpRequest): MemberSignUpResponse {
+        return memberService.signUp(request)
+    }
+}

--- a/src/main/kotlin/com/flab/inqueue/application/controller/WaitQueueController.kt
+++ b/src/main/kotlin/com/flab/inqueue/application/controller/WaitQueueController.kt
@@ -16,7 +16,7 @@ class WaitQueueController(
     fun enterWaitQueue(
         @PathVariable("eventId") eventId: String,
     ): JobResponse {
-        val principal = SecurityContextHolder.getContext().authentication as CommonPrincipal
+        val principal = SecurityContextHolder.getContext().authentication.principal as CommonPrincipal
         return jobService.enter(eventId, principal.userId!!)
     }
 
@@ -24,7 +24,7 @@ class WaitQueueController(
     fun retrieveWaitQueue(
         @PathVariable eventId: String,
     ): JobResponse {
-        val principal = SecurityContextHolder.getContext().authentication as CommonPrincipal
+        val principal = SecurityContextHolder.getContext().authentication.principal as CommonPrincipal
         return jobService.retrieve(eventId, principal.userId!!)
     }
 }

--- a/src/main/kotlin/com/flab/inqueue/domain/member/dto/MemberSignUpRequest.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/member/dto/MemberSignUpRequest.kt
@@ -1,0 +1,6 @@
+package com.flab.inqueue.domain.member.dto
+
+data class MemberSignUpRequest(
+    val name: String,
+    val phone: String? = null
+)

--- a/src/main/kotlin/com/flab/inqueue/domain/member/dto/MemberSignUpResponse.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/member/dto/MemberSignUpResponse.kt
@@ -4,5 +4,5 @@ import com.flab.inqueue.domain.member.entity.MemberKey
 
 data class MemberSignUpResponse(
     val name: String,
-    val memberKey: MemberKey
+    val key: MemberKey
 )

--- a/src/main/kotlin/com/flab/inqueue/domain/member/dto/MemberSignUpResponse.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/member/dto/MemberSignUpResponse.kt
@@ -1,0 +1,8 @@
+package com.flab.inqueue.domain.member.dto
+
+import com.flab.inqueue.domain.member.entity.MemberKey
+
+data class MemberSignUpResponse(
+    val name: String,
+    val memberKey: MemberKey
+)

--- a/src/main/kotlin/com/flab/inqueue/domain/member/entity/Member.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/member/entity/Member.kt
@@ -2,13 +2,13 @@ package com.flab.inqueue.domain.member.entity
 
 import com.flab.inqueue.common.domain.BaseEntity
 import com.flab.inqueue.security.common.Role
-import com.flab.inqueue.security.hmacsinature.utils.EncryptionUtil
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Entity(name = "MEMBER")
 class Member(
     var name: String,
+    var phone: String? = null,
     @Embedded
     val key: MemberKey,
     @ElementCollection
@@ -16,12 +16,8 @@ class Member(
         name = "MEMBER_ROLE",
         joinColumns = [JoinColumn(name = "member_id")]
     )
+    @Enumerated(EnumType.STRING)
     @Column(name = "role")
-    val roles: List<Role> = listOf(Role.USER)
-) : BaseEntity() {
-    val createdAt: LocalDateTime = LocalDateTime.now()
-
-    fun encryptMemberKey(encryptionUtil: EncryptionUtil) {
-        key.encryptClientSecret(encryptionUtil)
-    }
-}
+    val roles: List<Role> = listOf(Role.USER),
+    val createdDateTime: LocalDateTime = LocalDateTime.now()
+) : BaseEntity()

--- a/src/main/kotlin/com/flab/inqueue/domain/member/entity/MemberKey.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/member/entity/MemberKey.kt
@@ -8,7 +8,7 @@ class MemberKey(
     var clientId: String,
     var clientSecret: String,
 ) {
-    fun encryptClientSecret(encryptionUtil: EncryptionUtil) {
-        this.clientSecret = encryptionUtil.encrypt(this.clientSecret)
+    fun encrypt(encryptionUtil: EncryptionUtil): MemberKey {
+        return MemberKey(clientId, encryptionUtil.encrypt(this.clientSecret))
     }
 }

--- a/src/main/kotlin/com/flab/inqueue/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/member/service/MemberService.kt
@@ -1,0 +1,28 @@
+package com.flab.inqueue.domain.member.service
+
+import com.flab.inqueue.domain.member.dto.MemberSignUpRequest
+import com.flab.inqueue.domain.member.dto.MemberSignUpResponse
+import com.flab.inqueue.domain.member.entity.Member
+import com.flab.inqueue.domain.member.repository.MemberRepository
+import com.flab.inqueue.domain.member.utils.memberkeygenrator.MemberKeyGenerator
+import com.flab.inqueue.security.hmacsinature.utils.EncryptionUtil
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class MemberService(
+    private val memberRepository: MemberRepository,
+    private val memberKeyGenerator: MemberKeyGenerator,
+    private val encryptionUtil: EncryptionUtil
+) {
+
+    @Transactional
+    fun signUp(request: MemberSignUpRequest): MemberSignUpResponse {
+        val memberKey = memberKeyGenerator.generate()
+        val encryptedMemberKey = memberKey.encrypt(encryptionUtil)
+        val member = Member(request.name, request.phone, encryptedMemberKey)
+        memberRepository.save(member)
+        return MemberSignUpResponse(member.name, memberKey)
+    }
+
+}

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
@@ -60,7 +60,6 @@ class JobService(
         return JobVerificationResponse(isVerified)
     }
 
-    @Transactional
     fun close(eventId: String, userId: String) {
         val job = Job(eventId, userId, JobStatus.ENTER)
         if (!jobRedisRepository.isMember(job)) {

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/WaitQueueService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/WaitQueueService.kt
@@ -21,7 +21,6 @@ class WaitQueueService(
         return waitQueueRedisRepository.isMember(job)
     }
 
-    @Transactional
     fun retrieve(job: Job): JobResponse {
         if (!waitQueueRedisRepository.isMember(job)) {
             return JobResponse(JobStatus.TIMEOUT)

--- a/src/main/kotlin/com/flab/inqueue/security/WebSecurityConfig.kt
+++ b/src/main/kotlin/com/flab/inqueue/security/WebSecurityConfig.kt
@@ -31,7 +31,7 @@ class WebSecurityConfig(
     companion object {
         private val HMAC_AUTHENTICATION_REQUEST_MATCHER = AntPathRequestMatcher("/server/**")
         private val JWT_AUTHENTICATION_REQUEST_MATCHER = AntPathRequestMatcher("/client/**")
-        private val NONE_AUTHENTICATION_REQUEST = AntPathRequestMatcher("/server/v1/members", "POST")
+        private val NONE_AUTHENTICATION_REQUEST_MATCHER = AntPathRequestMatcher("/server/v1/members", "POST")
     }
 
     @Bean
@@ -40,7 +40,7 @@ class WebSecurityConfig(
             .csrf().disable()
             .cors().disable()
             .authorizeHttpRequests()
-            .requestMatchers(NONE_AUTHENTICATION_REQUEST).permitAll()
+            .requestMatchers(NONE_AUTHENTICATION_REQUEST_MATCHER).permitAll()
             .requestMatchers(HMAC_AUTHENTICATION_REQUEST_MATCHER).authenticated()
             .requestMatchers(JWT_AUTHENTICATION_REQUEST_MATCHER).authenticated()
             .anyRequest().permitAll()

--- a/src/main/kotlin/com/flab/inqueue/security/WebSecurityConfig.kt
+++ b/src/main/kotlin/com/flab/inqueue/security/WebSecurityConfig.kt
@@ -31,6 +31,7 @@ class WebSecurityConfig(
     companion object {
         private val HMAC_AUTHENTICATION_REQUEST_MATCHER = AntPathRequestMatcher("/server/**")
         private val JWT_AUTHENTICATION_REQUEST_MATCHER = AntPathRequestMatcher("/client/**")
+        private val NONE_AUTHENTICATION_REQUEST = AntPathRequestMatcher("/server/v1/members", "POST")
     }
 
     @Bean
@@ -39,6 +40,7 @@ class WebSecurityConfig(
             .csrf().disable()
             .cors().disable()
             .authorizeHttpRequests()
+            .requestMatchers(NONE_AUTHENTICATION_REQUEST).permitAll()
             .requestMatchers(HMAC_AUTHENTICATION_REQUEST_MATCHER).authenticated()
             .requestMatchers(JWT_AUTHENTICATION_REQUEST_MATCHER).authenticated()
             .anyRequest().permitAll()

--- a/src/test/kotlin/com/flab/inqueue/TestContainer.kt
+++ b/src/test/kotlin/com/flab/inqueue/TestContainer.kt
@@ -10,7 +10,7 @@ abstract class TestContainer {
 
     companion object {
         @JvmStatic
-        val redisContainer: GenericContainer<*> = GenericContainer("redis:5.0.3-alpine").withExposedPorts(6379)
+        val redisContainer: GenericContainer<*> = GenericContainer("redis:7.0.11").withExposedPorts(6379).withExposedPorts(6379)
 
         @JvmStatic
         @DynamicPropertySource

--- a/src/test/kotlin/com/flab/inqueue/api/JobTest.kt
+++ b/src/test/kotlin/com/flab/inqueue/api/JobTest.kt
@@ -2,7 +2,6 @@ package com.flab.inqueue.api
 
 import com.flab.inqueue.AcceptanceTest
 import com.flab.inqueue.REST_DOCS_DOCUMENT_IDENTIFIER
-import com.flab.inqueue.createEventRequest
 import com.flab.inqueue.domain.event.dto.EventInformation
 import com.flab.inqueue.domain.event.entity.Event
 import com.flab.inqueue.domain.event.repository.EventRepository
@@ -13,6 +12,7 @@ import com.flab.inqueue.domain.member.utils.memberkeygenrator.MemberKeyGenerator
 import com.flab.inqueue.domain.queue.entity.Job
 import com.flab.inqueue.domain.queue.entity.JobStatus
 import com.flab.inqueue.domain.queue.repository.JobRedisRepository
+import com.flab.inqueue.fixture.createEventRequest
 import com.flab.inqueue.security.hmacsinature.createHmacAuthorizationHeader
 import com.flab.inqueue.security.hmacsinature.utils.EncryptionUtil
 import org.assertj.core.api.Assertions.*
@@ -66,9 +66,8 @@ class JobTest : AcceptanceTest() {
         notEncryptedUserMemberKey = memberKeyGenerator.generate()
         member = Member(
             "TEST_MEMBER",
-            MemberKey(notEncryptedUserMemberKey.clientId, notEncryptedUserMemberKey.clientSecret)
+            key = notEncryptedUserMemberKey.encrypt(encryptionUtil)
         )
-        member.encryptMemberKey(encryptionUtil)
         memberRepository.save(member)
 
         event = createEventRequest(

--- a/src/test/kotlin/com/flab/inqueue/api/UserTest.kt
+++ b/src/test/kotlin/com/flab/inqueue/api/UserTest.kt
@@ -71,10 +71,9 @@ class UserTest : AcceptanceTest() {
         hmacSignaturePayload = "http://localhost:${port}" + ISSUE_TOKEN_URL
         notEncryptedUserMemberKey = memberKeyGenerator.generate()
         member = Member(
-            "TEST_MEMBER",
-            MemberKey(notEncryptedUserMemberKey.clientId, notEncryptedUserMemberKey.clientSecret)
+            name = "TEST_MEMBER",
+            key = notEncryptedUserMemberKey.encrypt(encryptionUtil)
         )
-        member.encryptMemberKey(encryptionUtil)
         memberRepository.save(member)
 
         event = createEventRequest(

--- a/src/test/kotlin/com/flab/inqueue/domain/queue/service/WaitQueueServiceTest.kt
+++ b/src/test/kotlin/com/flab/inqueue/domain/queue/service/WaitQueueServiceTest.kt
@@ -8,8 +8,8 @@ import com.flab.inqueue.support.UnitTest
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.*
-import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.DisplayName
 import java.util.*
 
 @UnitTest
@@ -35,6 +35,8 @@ class WaitQueueServiceTest {
         )
         val expectedRank = 5L
         every { waitQueueRedisRepository.rank(job) } returns expectedRank
+        every { waitQueueRedisRepository.isMember(job) } returns true
+        every { waitQueueRedisRepository.updateUserTtl(job) } returns Unit
 
         //given
         val jobResponse = waitQueueService.retrieve(job)
@@ -44,7 +46,7 @@ class WaitQueueServiceTest {
     }
 
 
-    @org.junit.Test
+    @Test
     @DisplayName("대기열 조회 Time Out")
     fun retrieve_time_out_job() {
         // given

--- a/src/test/kotlin/com/flab/inqueue/security/hmacsinature/HmacSignatureSecurityTest.kt
+++ b/src/test/kotlin/com/flab/inqueue/security/hmacsinature/HmacSignatureSecurityTest.kt
@@ -49,21 +49,19 @@ class HmacSignatureSecurityTest : AcceptanceTest() {
         hmacSignaturePayloadWithUser = "http://localhost:${port}" + HMAC_SECURITY_TEST_URI
         notEncryptedUserMemberKey = memberKeyGenerator.generate()
         testUser = Member(
-            "USER",
-            MemberKey(notEncryptedUserMemberKey.clientId, notEncryptedUserMemberKey.clientSecret)
+            name = "USER",
+            key = notEncryptedUserMemberKey.encrypt(encryptionUtil)
         )
-        testUser.encryptMemberKey(encryptionUtil)
         memberRepository.save(testUser)
 
         // ROLE_ADMIN
         hmacSignaturePayloadWithAdmin = "http://localhost:${port}" + HMAC_SECURITY_TEST_WITH_ADMIN_USER_URI
         notEncryptedAdminMemberKey = memberKeyGenerator.generate()
         testAdmin = Member(
-            "ADMIN",
-            MemberKey(notEncryptedAdminMemberKey.clientId, notEncryptedAdminMemberKey.clientSecret),
-            listOf(Role.USER, Role.ADMIN)
+            name = "ADMIN",
+            key = notEncryptedAdminMemberKey.encrypt(encryptionUtil),
+            roles = listOf(Role.USER, Role.ADMIN)
         )
-        testAdmin.encryptMemberKey(encryptionUtil)
         memberRepository.save(testAdmin)
     }
 


### PR DESCRIPTION
이슈 번호 : #36 

- 해당 작업은 시큐리티 인증을 거치지 않는다.
- 회원 가입이 완료되면 MemberKey(ClientId, ClientSecret)을 발급한다.
- DB 저장시 MemberKey의 ClientSecret을 AES256암호화하여 저장하고, 사용자에게는 암호화 되지 않은 정보를 노출한다.