### PR TITLE
대기열, 작업열 진입시 리팩터링

### DIFF
--- a/src/main/kotlin/com/flab/inqueue/domain/queue/entity/Job.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/entity/Job.kt
@@ -5,8 +5,7 @@ import java.time.Instant
 class Job(
     val eventId: String,
     val userId: String,
-    var status: JobStatus = JobStatus.WAIT,
-    val redisKeySecTTL : Instant? = null
+    var status: JobStatus = JobStatus.WAIT
 ) {
 
     private val redisKey =  status.makeRedisKey(this.eventId)

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/repository/UserRedisRepository.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/repository/UserRedisRepository.kt
@@ -13,8 +13,9 @@ class UserRedisRepository(
 
     @Transactional
     fun register(job: Job) {
-        redisTemplate.opsForSet().add(job.redisKey(), job.redisValue() )
-        job.redisKeySecTTL?.let { redisTemplate.expireAt(job.redisKey(), it) }
+        if(job.status == JobStatus.ENTER){
+            redisTemplate.opsForSet().add(job.redisKey(), job.redisValue() )
+        }
         redisTemplate.opsForSet().add(job.redisValue() ,job.redisValue() )
         // TODO:대기열, 작업엽 검증에 있어서 TTL 이 달라야 할 것 같습니다.
         redisTemplate.expire(job.redisValue(), 1L, TimeUnit.SECONDS)

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
@@ -17,8 +17,8 @@ class JobService(
         val event = findEvent(eventId)
 
         val job =
-            if (isEnterJob(event)) Job(eventId, userId, JobStatus.ENTER, event.period.convertInstant())
-            else Job(eventId, userId, JobStatus.WAIT, event.period.convertInstant())
+            if (isEnterJob(event)) Job(eventId, userId, JobStatus.ENTER)
+            else Job(eventId, userId, JobStatus.WAIT)
 
         return queueService.waitQueueRegister(job)
     }

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/JobService.kt
@@ -35,12 +35,11 @@ class JobService(
 
     private fun isEnterJob(event: Event): Boolean {
 
-        // 에서 조회를 해야함
-        val enterQueueSize = queueService.size(JobStatus.ENTER.makeRedisKey(event.eventId)) ?: 0
-        val waitQueueSize = queueService.size(JobStatus.WAIT.makeRedisKey(event.eventId)) ?: 0
+        val enterQueueSize = queueService.setSize(JobStatus.ENTER.makeRedisKey(event.eventId)) ?: 0
+        val waitQueueSize = queueService.waitSize(JobStatus.WAIT.makeRedisKey(event.eventId)) ?: 0
 
         if (waitQueueSize > 0) return false
-        if (enterQueueSize > event.jobQueueLimitTime) return false
+        if (enterQueueSize >= event.jobQueueLimitTime) return false
 
         return true
     }

--- a/src/main/kotlin/com/flab/inqueue/domain/queue/service/QueueService.kt
+++ b/src/main/kotlin/com/flab/inqueue/domain/queue/service/QueueService.kt
@@ -30,8 +30,11 @@ class QueueService(
         return QueueResponse(JobStatus.WAIT, QueueInfo(waitSecond, rank.toInt()))
     }
 
-    fun size(key: String): Long? {
+    fun setSize(key: String): Long? {
         return userRedisRepository.size(key)
+    }
+    fun waitSize(key: String): Long? {
+        return waitQueueRedisRepository.size(key)
     }
 
     fun isMember(job: Job): Boolean {

--- a/src/test/kotlin/com/flab/inqueue/domain/queue/redis/JobSetRedis.kt
+++ b/src/test/kotlin/com/flab/inqueue/domain/queue/redis/JobSetRedis.kt
@@ -36,8 +36,7 @@ class JobSetRedis @Autowired constructor(
     @Test
     @DisplayName("redis set ttl 테스트")
     fun testRedisTTL() {
-        val expireInstant = LocalDateTime.now().plusSeconds(1).toInstant(ZoneOffset.ofHours(9))
-        val job = Job("testEventId", UUID.randomUUID().toString(), JobStatus.ENTER,expireInstant)
+        val job = Job("testEventId", UUID.randomUUID().toString(), JobStatus.ENTER)
 
         val startTime = System.currentTimeMillis()
         userRedisRepository.register(job)


### PR DESCRIPTION
#38 

### 요구사항 및 문제정의
레디스에서 key가 중복 되는 현상 존재 하였습니다. 

set 자료구조 대기열 체크 
sadd "prefix:eventId" "prefix:eventId:userId" 

실제 대기열 자료구조 
zadd "prefix:eventId" "prefix:eventId:userId" 
키가 중복되는 현상 발생 

### 변경 사항 및 고려사항

- 대기열 체크시에 set자료구조가 아닌 sortedSet 에서 전체 사이즈를 가져오도록 변경

- set 자료구조 사용시 key가 `prefix:eventId`일때, TTL제거
1. 업데이트할때마다 Instant객체를 생성해서 TTL을 적용하는게 불필요하다고 판단. 
2. 행사가 종료되면 해당 key를 제거하는 배치를 돌리는것이 현명할것으로 판단
